### PR TITLE
Use docker container to run services for saas-api

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,29 @@ git checkout tags/v1.8.20
 make geth
 sudo cp ~/workspace/go-ethereum/build/bin/geth /usr/local/bin
 ```
+* [Only Development] Use docker to run required services
 
-* Start RabbitMQ
+Install docker if not already installed. Refer [this](https://docs.docker.com/docker-for-mac/install/).
+
+Start services:
 ```
-brew services start rabbitmq
+docker-compose up
 ```
+Above command will start below services
+
+|  Service  	|     Port    	|
+|:---------:	|:-----------:	|
+|   mysql   	|     3306    	|
+| memcached 	|    11211    	|
+|   redis   	|     6379    	|
+|  Rabbitmq 	| 15672, 5672 	|
+| Dynamo db 	|     8000    	|
+
+Stop services:
+```
+docker-compose down
+```
+
 
 * Install all the packages.
 ```
@@ -42,12 +60,6 @@ source set_env_vars.sh
 node  executables/flush/sharedMemcached.js
 ```
 
-## [Only Development] Start Dynamo DB
-```bash
-rm ~/dynamodb_local_latest/shared-local-instance.db
-
-java -Djava.library.path=~/dynamodb_local_latest/DynamoDBLocal_lib/ -jar ~/dynamodb_local_latest/DynamoDBLocal.jar -sharedDb -dbPath ~/dynamodb_local_latest/
-```
 
 ## ORIGIN CHAIN SETUP
 [README-ORIGIN-SETUP.md](README-ORIGIN-SETUP.md)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,27 @@
+mysql:
+  image: mysql
+  ports:
+    - "3306:3306"
+  environment:
+    MYSQL_ROOT_PASSWORD: root
+
+memcached:
+  image: memcached
+  ports:
+    - "11211:11211"
+
+redis:
+  image: redis
+  ports:
+    - "6379:6379"
+
+rabbitmq:
+  image: rabbitmq:3.6.1-management
+  ports:
+    - "15672:15672"
+    - "5672:5672"
+
+dynamodb:
+    image: "amazon/dynamodb-local"
+    ports:
+      - "8000:8000"


### PR DESCRIPTION
This PR is about enabling docker in saas-api to start below services: 

|  Service  	|     Port    	|
|:---------:	|:-----------:	|
|   mysql   	|     3306    	|
| memcached 	|    11211    	|
|   redis   	|     6379    	|
|  Rabbitmq 	| 15672, 5672 	|
| Dynamo db 	|     8000    	|

There are various advantages of using docker container in saas-api: 
 1. This will save a lot of dev effort in installing these services on the local machine. It just executing simple command `docker-compose up`. 

2. Maintaining versions across dev machines will be very easy. Just update `docker-compose.yml` file with the correct version. This will make sure, all the devs are using the same versions.

3.  All the above services will run in a docker container exposed on the fixed port without affecting/corrupting local dev environment/machine.

Let me know your feedback, happy to discuss more 🙌 

